### PR TITLE
Fix generate-stackbrew to use the correct commit

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -23,4 +23,5 @@ for va in "${versionAliases[@]}"; do
 done
 
 echo
+commit="$(git log -1 --format='format:%H' onbuild)"
 echo "onbuild: ${url}@${commit} onbuild"


### PR DESCRIPTION
Onbuild tag was using the same commit as the regular build.
