### PR TITLE
Add missing dependency: psql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.1.2
 
-RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nodejs postgresql-client --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_VERSION 4.1.5
 

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -9,7 +9,7 @@ ONBUILD RUN bundle install --system
 
 ONBUILD ADD . /usr/src/app
 
-RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nodejs postgresql-client --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 3000
 CMD ["rails", "server"]


### PR DESCRIPTION
Needed in order to make `./bin/rails dbconsole -p` work.
