### PR TITLE
Update onbuild variant to match Ruby's changes

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -1,13 +1,16 @@
 FROM ruby:2.1.3
 
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ONBUILD ADD Gemfile /usr/src/app/
-ONBUILD ADD Gemfile.lock /usr/src/app/
-ONBUILD RUN bundle install --system
+ONBUILD COPY Gemfile /usr/src/app/
+ONBUILD COPY Gemfile.lock /usr/src/app/
+ONBUILD RUN bundle install
 
-ONBUILD ADD . /usr/src/app
+ONBUILD COPY . /usr/src/app
 
 RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This will _probably_ fix #11, but it definitely leads to a more deterministic experience regardless.

Before this can merge, we need to update `ruby` in https://github.com/docker-library/official-images.
