### PR TITLE
Adding support for building a rails image with the app directory mounted as a shared mount

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /usr/src/app
 
 ONBUILD COPY Gemfile /usr/src/app/
 ONBUILD COPY Gemfile.lock /usr/src/app/
-ONBUILD RUN bundle install
 
 ONBUILD COPY . /usr/src/app
 
@@ -16,4 +15,6 @@ RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -r
 RUN apt-get update && apt-get install -y mysql-client postgresql-client sqlite3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 3000
+COPY ./entrypoint.sh  /
+ENTRYPOINT [ "/entrypoint.sh"]
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/onbuild/entrypoint.sh
+++ b/onbuild/entrypoint.sh
@@ -3,5 +3,6 @@
 [ "$RUN_BUNDLE_INSTALL" == "false" ] || bundle install
 [ "$RUN_MIGRATIONS" == "true" ] && rake db:migrate
 [ "$RUN_DB_SETUP" == "true" ] && rake db:setup
+[ -n "$RUN_INIT_SCRIPT" ] && $RUN_INIT_SCRIPT
 
 exec "$@"

--- a/onbuild/entrypoint.sh
+++ b/onbuild/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+[ "$RUN_BUNDLE_INSTALL" == "false" ] || bundle install
+[ "$RUN_MIGRATIONS" == "true" ] && rake db:migrate
+[ "$RUN_DB_SETUP" == "true" ] && rake db:setup
+
+exec "$@"


### PR DESCRIPTION
As it stands the container will include the source code ver when the onbuild image was built. Not when the container was run.

By simply adding an entrypoint script, and moving the bundle install to entrypoint, along with the ability to run db migrate db setup, the container is able to be run with the usr/src/app mounted as a volume. This allows the container to be rerun with the latest changes to your app included. 

i.e. `docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app your_onbuild_image` will just work™ 