### PR TITLE
Relax FROM specificity to avoid unnecessary bumps every time ruby does

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.2
+FROM ruby:2.2
 
 # see update.sh for why all "apt-get install"s have to stay as one long line
 RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.2
+FROM ruby:2.2
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/update.sh
+++ b/update.sh
@@ -15,7 +15,9 @@ echo >> onbuild/Dockerfile
 echo 'EXPOSE 3000' >> onbuild/Dockerfile
 echo 'CMD ["rails", "server", "-b", "0.0.0.0"]' >> onbuild/Dockerfile
 
+sed -ri 's/^(FROM ruby):.*/\1:'"$rubyBase"'/' onbuild/Dockerfile
+
 sed -ri '
-	s/^FROM .*/'"$(grep '^FROM' onbuild/Dockerfile | head -1)"'/;
-	s/^(ENV RAILS_VERSION) .*/\1 '"$current"'/
+	s/^FROM .*/'"$(grep -m1 '^FROM' onbuild/Dockerfile)"'/;
+	s/^(ENV RAILS_VERSION) .*/\1 '"$current"'/;
 ' Dockerfile


### PR DESCRIPTION
```console
$ ./update.sh
+ curl -sSL https://raw.githubusercontent.com/docker-library/ruby/master/2.2/onbuild/Dockerfile -o onbuild/Dockerfile
+ echo
+ grep '^RUN.*apt-get install' Dockerfile
+ echo
+ echo 'EXPOSE 3000'
+ echo 'CMD ["rails", "server", "-b", "0.0.0.0"]'
+ sed -ri 's/^(FROM ruby):.*/\1:2.2/' onbuild/Dockerfile
++ grep -m1 '^FROM' onbuild/Dockerfile
+ sed -ri '
	s/^FROM .*/FROM ruby:2.2/;
	s/^(ENV RAILS_VERSION) .*/\1 4.2.1/;
' Dockerfile
```