### PR TITLE
Avoid warning about running Bundler as root

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -3,6 +3,9 @@ FROM ruby:2.2
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
+# avoid warning about running Bundler as root
+RUN bundle config --global silence_root_warning 1
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
fixes #10 

Shouldn't be a problem for earlier versions of bundler